### PR TITLE
#35 Google Analyticsタグを埋め込む

### DIFF
--- a/app/src/layouts/Layout.astro
+++ b/app/src/layouts/Layout.astro
@@ -39,6 +39,15 @@ const fallbackImageURL = new URL(SITE.ogImage, Astro.url.origin).href;
 <!DOCTYPE html>
 <html lang="ja">
   <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-MG2B225WK3"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-MG2B225WK3');
+    </script>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width" />
     <link rel="icon" type="image/svg+xml" href={faviconImageURL} />


### PR DESCRIPTION
## Issue

* #35 

## やったこと

* GA4用タグを設定。

## できるようになること

* Google Analytics 4にてページアクセス解析ができるようになった。

## 動作確認

* [x] タグを埋め込み、アクティブユーザーとして計測できることを確認。

close #35 