### PR TITLE
#86 ページ読み込み時にロゴが拡大表示される

### DIFF
--- a/src/components/LogoImage.astro
+++ b/src/components/LogoImage.astro
@@ -12,8 +12,6 @@ const { className } = Astro.props;
     xmlns:xlink="http://www.w3.org/1999/xlink"
     x="0"
     y="0"
-    width="400"
-    height="80"
     viewBox="0, 0, 400, 80"
   >
     <defs>


### PR DESCRIPTION
## Issue

* #86 

## やったこと

* `LogoImage.astro`に記述されているsvgタグからwidth, height属性を削除。

close #86 