### PR TITLE
#88 View Transitions APIを一時的に無効化

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,6 +1,5 @@
 ---
 import { SITE } from "@config";
-import { ViewTransitions } from 'astro:transitions';
 import "../styles/github-markdown-custom.min.css";
 import "../styles/base.css";
 
@@ -78,7 +77,6 @@ const fallbackImageURL = new URL(SITE.ogImage, Astro.url.origin).href;
         ? fallbackImageURL
         : socialImageURL}
     />
-    <ViewTransitions />
 
     <!-- Adobe Fonts -->
     <script>


### PR DESCRIPTION
## Issue

* #88 

## やったこと

* View Transitions APIを有効化するとヘッダーボタンが一部機能しない不具合が発生したため、一時的にView Transitions APIを無効化した。

## やらないこと

* View Transitions APIを有効化したままでヘッダーボタンを正常に動作させるよう修正すること。

## できなくなること

* ビュートランジションが使えない。